### PR TITLE
See PR body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "task-react-modern",
+  "name": "react-kanbanboard",
   "version": "0.1.0",
   "private": true,
   "homepage": "https://thetalljerry.github.io/kanbanboard-app-react",
   "dependencies": {
+    "@emotion/react": "^11.10.6",
+    "@emotion/styled": "^11.10.6",
+    "@mui/material": "^5.11.10",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
@@ -11,7 +14,7 @@
     "react-beautiful-dnd": "^13.1.0",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^2.1.3",
     "uuid": "^8.3.2",
     "web-vitals": "^1.1.2"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import Kanban from "./Kanban";
+import React from "react"
 import "./App.css";
 
 function App() {

--- a/src/Kanban.js
+++ b/src/Kanban.js
@@ -148,10 +148,16 @@ const Kanban = () => {
               <KanbanModal
                 closeModal={closeModal}
                 addTask={addTask}
-                columnData={modal}
+                columnData={columns[modal - 1]}
+                modal={modal}
               />
             )}
-            {popup && popup != 1 && <KanbanPopup closePopup={closePopup} columnData={columns[popup - 1]} />}
+            {popup && popup !== 1 && (
+              <KanbanPopup
+                closePopup={closePopup}
+                columnData={columns[popup - 1]}
+              />
+            )}
             <h1 className="Kanban-title">Kanban</h1>
             <div className="Kanban-columns-container">
               {columns.map((c) => {

--- a/src/KanbanModal.css
+++ b/src/KanbanModal.css
@@ -9,13 +9,9 @@
 }
 
 .KanbanModal-content {
-    position: fixed;
     background: white;
     border-radius: 10px;
     width: 15%;
-    min-width: min-content;
-    height: 30%;
-    min-height: min-content;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
@@ -24,6 +20,7 @@
     align-items: center;
     justify-content: center;
     position: relative;
+    overflow: auto;
 }
 
 .KanbanModal-close-btn:before {
@@ -43,7 +40,7 @@
     align-items: center;
     justify-content: center;
     width: 220px;
-    height: 200px;
+    height: fit-content;
 }
 
 .KanbanModal-input-container {

--- a/src/KanbanModal.js
+++ b/src/KanbanModal.js
@@ -2,65 +2,97 @@ import React from "react";
 import "./KanbanModal.css";
 import useInputState from "./useInputState";
 import { v4 as uuidv4 } from "uuid";
+import TextField from "@mui/material/TextField";
 
 const KanbanModal = (props) => {
-    const [text, handleChangeText] = useInputState("");
-    const [user, handleChangeUser] = useInputState("");
+  const [task, handleChangeTask] = useInputState("");
+  const [user, handleChangeUser] = useInputState("");
+  const [first, handleChangeFirst] = useInputState("");
+  const [second, handleChangeSecond] = useInputState("");
+  const [third, handleChangeThird] = useInputState("");
 
-    const idColumn = props.columnData;
+  const columnData = props.columnData;
 
-    const newTask = {
-        id: uuidv4(),
-        text: text,
-        idColumn: idColumn,
-        user: user,
-    };
+  const newTask = {
+    id: uuidv4(),
+    text: task,
+    idColumn: props.modal,
+    user: user,
+  };
 
-    return (
-        <div className="KanbanModal">
-            <section className="KanbanModal-content">
-                <span
-                    className="KanbanModal-close-btn"
-                    onClick={props.closeModal}
-                ></span>
-                <form
-                    className="KanbanModal-form"
-                    onSubmit={(e) => {
-                        e.preventDefault();
-                        props.addTask(newTask);
-                    }}
-                >
-                    <div className="KanbanModal-input-container">
-                        <label htmlFor="task">Task: </label>
-                        <textarea
-                            className="KanbanModal-input"
-                            type="text"
-                            cols="20"
-                            rows="5"
-                            value={text}
-                            onChange={handleChangeText}
-                            name="task"
-                            id="task"
-                        ></textarea>
-                    </div>
-                    <div className="KanbanModal-input-container">
-                        <label htmlFor="user">For: </label>
-                        <input
-                            className="KanbanModal-input"
-                            type="text"
-                            name="user"
-                            id="user"
-                            value={user}
-                            onChange={handleChangeUser}
-                        ></input>
-                    </div>
-                    <button className="KanbanModal-input-submit-btn">
-                        Submit
-                    </button>
-                </form>
-            </section>
-        </div>
-    );
+  return (
+    <div className="KanbanModal">
+      <section className="KanbanModal-content">
+        <span
+          className="KanbanModal-close-btn"
+          onClick={props.closeModal}
+        ></span>
+        <form
+          className="KanbanModal-form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            props.addTask(newTask);
+          }}
+        >
+          <div className="KanbanModal-input-container">
+            <TextField
+              id="filled-search"
+              label="Task:"
+              type="search"
+              value={task}
+              onChange={handleChangeTask}
+            />
+          </div>
+          <div className="KanbanModal-input-container">
+            <TextField
+              id="filled-search"
+              label="For:"
+              type="search"
+              value={user}
+              onChange={handleChangeUser}
+            />
+          </div>
+          <div className="KanbanModal-input-container">
+            <TextField
+              id="standard-multiline-static"
+              helperText={columnData.first}
+              multiline
+              label="Question 1:"
+              rows={3}
+              defaultValue="Default Value"
+              value={first}
+              onChange={handleChangeFirst}
+            />
+          </div>
+          <div className="KanbanModal-input-container">
+            <TextField
+              id="standard-multiline-static"
+              helperText={columnData.second}
+              multiline
+              label="Question 2:"
+              rows={3}
+              defaultValue="Default Value"
+              value={second}
+              onChange={handleChangeSecond}
+            />
+          </div>
+          <div className="KanbanModal-input-container">
+            <TextField
+              id="standard-multiline-static"
+              helperText={columnData.third}
+              multiline
+              label="Question 3:"
+              rows={3}
+              defaultValue="Default Value"
+              value={third}
+              onChange={handleChangeThird}
+            />
+          </div>
+          <button className="KanbanModal-input-submit-btn">Submit</button>
+        </form>
+      </section>
+    </div>
+  );
 };
 
 export default KanbanModal;

--- a/src/KanbanPopup.css
+++ b/src/KanbanPopup.css
@@ -9,13 +9,9 @@
 }
 
 .KanbanPopup-content {
-    position: fixed;
     background: white;
     border-radius: 10px;
     width: 15%;
-    min-width: min-content;
-    height: 30%;
-    min-height: min-content;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
@@ -24,6 +20,7 @@
     align-items: center;
     justify-content: center;
     position: relative;
+    overflow: auto;
 }
 
 .KanbanPopup-close-btn:before {
@@ -43,7 +40,7 @@
     align-items: center;
     justify-content: center;
     width: 220px;
-    height: 200px;
+    height: fit-content;
 }
 
 .KanbanPopup-input-container {

--- a/src/KanbanPopup.js
+++ b/src/KanbanPopup.js
@@ -1,6 +1,7 @@
 import React from "react";
 import "./KanbanPopup.css";
 import useInputState from "./useInputState";
+import TextField from "@mui/material/TextField";
 
 const KanbanPopup = (props) => {
   const [first, handleChangeFirst] = useInputState("");
@@ -22,44 +23,41 @@ const KanbanPopup = (props) => {
             e.preventDefault();
           }}
         >
-          <div className="KanbanPopup-input-container">
-            <div className="KanbanModel-input-label">
-              <label htmlFor="first">{columnData.first}</label>
-            </div>
-            <input
-              className="KanbanPopup-input"
-              type="text"
-              name="first"
-              id="first"
+          <div className="KanbanModal-input-container">
+            <TextField
+              id="standard-multiline-static"
+              helperText={columnData.first}
+              multiline
+              label="Question 1:"
+              rows={3}
+              defaultValue="Default Value"
               value={first}
               onChange={handleChangeFirst}
-            ></input>
+            />
           </div>
-          <div className="KanbanPopup-input-container">
-            <div className="KanbanModel-input-label">
-              <label htmlFor="second">{columnData.second}</label>
-            </div>
-            <input
-              className="KanbanPopup-input"
-              type="text"
-              name="second"
-              id="second"
+          <div className="KanbanModal-input-container">
+            <TextField
+              id="standard-multiline-static"
+              helperText={columnData.second}
+              multiline
+              label="Question 2:"
+              rows={3}
+              defaultValue="Default Value"
               value={second}
               onChange={handleChangeSecond}
-            ></input>
+            />
           </div>
-          <div className="KanbanPopup-input-container">
-            <div className="KanbanModel-input-label">
-              <label htmlFor="third">{columnData.third}</label>
-            </div>
-            <input
-              className="KanbanPopup-input"
-              type="text"
-              name="third"
-              id="third"
+          <div className="KanbanModal-input-container">
+            <TextField
+              id="standard-multiline-static"
+              helperText={columnData.third}
+              multiline
+              label="Question 3:"
+              rows={3}
+              defaultValue="Default Value"
               value={third}
               onChange={handleChangeThird}
-            ></input>
+            />
           </div>
           <button
             className="KanbanPopup-input-submit-btn"

--- a/src/KanbanTask.js
+++ b/src/KanbanTask.js
@@ -54,7 +54,7 @@ const KanbanTask = (props) => {
                                         props.removeTask(props.task.id)
                                     }
                                 >
-                                    Cancel
+                                    Remove
                                 </button>
                             </div>
                         </>


### PR DESCRIPTION
- Shows the first set of questions when adding tasks
- Uses mui for textfields which also allows for multi line entries (for the RQAs): 
![Capture](https://user-images.githubusercontent.com/67441706/221388166-ed2c51d2-59d8-49b3-a41e-cd678806ea3d.PNG)


## Previous add task: 
![current](https://user-images.githubusercontent.com/67441706/221388060-bb040df4-94a6-4888-984d-5609fa2c6b3a.PNG)
## Current add task: 
![after1](https://user-images.githubusercontent.com/67441706/221388075-182b8fb0-2908-4683-9500-b8288db6a056.PNG)
## Previous second set of questions:
![Capture](https://user-images.githubusercontent.com/67441706/221388093-604b5a81-dbfd-4cbd-9a47-caa011d93bdc.PNG)
## Current second set of questions: 
![after2](https://user-images.githubusercontent.com/67441706/221388095-68a72301-d491-42ec-aec2-ea527d7239e9.PNG)
Third set similar to second
